### PR TITLE
feat: Simplify configuration and add EU and Self-Hosted support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Before installing the GitGuardian MCP servers, ensure you have the following pre
 
 Below are instructions for installing the GitGuardian MCP servers with various AI editors and interfaces.
 
-Currently, the MCP server only works with SaaS GitGuardian workspaces, not self-hosted ones.
+The MCP server supports both GitGuardian SaaS and self-hosted instances. For self-hosted configurations, see the [Self-Hosted GitGuardian Configuration](#self-hosted-gitguardian-configuration) section below.
 
 ### Installation with Cursor
 
@@ -175,6 +175,98 @@ To use the GitGuardian MCP server with [Windsurf](https://www.windsurf.ai/):
 2. After you log in to GitGuardian and authorize the application, you'll be redirected back to the local server
 3. The authentication token will be securely stored for future use
 4. The next time you start the server, it will reuse the stored token without requiring re-authentication
+
+## Self-Hosted GitGuardian Configuration
+
+The MCP server supports self-hosted GitGuardian instances. To configure it for your self-hosted environment, you'll need to set additional environment variables.
+
+### Environment Variables for Self-Hosted Instances
+
+Set these environment variables in your MCP client configuration:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `GITGUARDIAN_API_URL` | Your self-hosted GitGuardian base URL | `https://dashboard.gitguardian.mycorp.local` |
+| `GITGUARDIAN_AUTH_METHOD` | Authentication method: `token` or `web` | `token` |
+| `GITGUARDIAN_API_KEY` | Your API key (required for token auth) | `your-api-key-here` |
+
+### Configuration Examples
+
+#### Cursor with Self-Hosted GitGuardian (Token Authentication)
+
+```json
+{
+  "mcpServers": {
+    "GitGuardianDeveloper": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/GitGuardian/gg-mcp.git",
+        "developer-mcp-server"
+      ],
+      "env": {
+        "GITGUARDIAN_API_URL": "https://dashboard.gitguardian.mycorp.local",
+        "GITGUARDIAN_AUTH_METHOD": "token",
+        "GITGUARDIAN_API_KEY": "your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+#### Claude Desktop with Self-Hosted GitGuardian
+
+```json
+{
+  "mcpServers": {
+    "GitGuardianDeveloper": {
+      "command": "/path/to/uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/GitGuardian/gg-mcp.git",
+        "developer-mcp-server"
+      ],
+      "env": {
+        "GITGUARDIAN_API_URL": "https://dashboard.gitguardian.mycorp.local",
+        "GITGUARDIAN_AUTH_METHOD": "token",
+        "GITGUARDIAN_API_KEY": "your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+### Authentication Methods for Self-Hosted Instances
+
+#### Token Authentication (Recommended)
+
+For self-hosted instances, token authentication is the most reliable method:
+
+1. Generate an API token in your GitGuardian dashboard
+2. Set `GITGUARDIAN_AUTH_METHOD=token`
+3. Set `GITGUARDIAN_API_KEY` to your API token
+4. Set `GITGUARDIAN_API_URL` to your API endpoint
+
+#### OAuth Authentication
+
+OAuth is also supported for self-hosted instances:
+
+1. Set `GITGUARDIAN_AUTH_METHOD=web`
+2. Set `GITGUARDIAN_API_URL` to your API endpoint
+
+### API URL Formats
+
+For self-hosted instances, you only need to provide the **base URL** of your GitGuardian instance:
+
+- `https://dashboard.gitguardian.mycorp.local` - Base URL (recommended)
+- `https://gitguardian.company.com` - Custom domain base URL
+- `https://gg.internal.corp` - Internal domain base URL
+
+The MCP server will **automatically** append the correct API path (`/exposed/v1`) for self-hosted instances. You can also provide the full API URL if preferred:
+
+- `https://dashboard.gitguardian.mycorp.local/exposed/v1` - Full API URL (also works)
+
+The dashboard URL (used for OAuth authentication) will be automatically derived from the API URL.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Before installing the GitGuardian MCP servers, ensure you have the following pre
 
 Below are instructions for installing the GitGuardian MCP servers with various AI editors and interfaces.
 
-The MCP server supports both GitGuardian SaaS and self-hosted instances. For self-hosted configurations, see the [Self-Hosted GitGuardian Configuration](#self-hosted-gitguardian-configuration) section below.
+The MCP server supports both GitGuardian SaaS and self-hosted instances.
 
 ### Installation with Cursor
 
@@ -63,6 +63,8 @@ The MCP server supports both GitGuardian SaaS and self-hosted instances. For sel
 For Developer MCP Server:
 
 [![Install Developer MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=GitGuardianDeveloper&config=eyJjb21tYW5kIjoidXZ4IC0tZnJvbSBnaXQraHR0cHM6Ly9naXRodWIuY29tL0dpdEd1YXJkaWFuL2dnLW1jcC5naXQgZGV2ZWxvcGVyLW1jcC1zZXJ2ZXIifQ%3D%3D)
+
+> **Note**: The one-click install sets up the default US SaaS configuration. For EU SaaS, self-hosted instances, or token authentication, you'll need to manually add environment variables as shown in the [Configuration section](#configuration-for-different-gitguardian-instances).
 
 **Manual Configuration**:
 
@@ -176,34 +178,20 @@ To use the GitGuardian MCP server with [Windsurf](https://www.windsurf.ai/):
 3. The authentication token will be securely stored for future use
 4. The next time you start the server, it will reuse the stored token without requiring re-authentication
 
-## Self-Hosted GitGuardian Configuration
+## Configuration for Different GitGuardian Instances
 
-The MCP server supports self-hosted GitGuardian instances. To configure it for your self-hosted environment, you'll need to set additional environment variables.
+The MCP server defaults to GitGuardian SaaS (US region). For other instances, you'll need to specify the URL:
 
-### Environment Variables for Self-Hosted Instances
+### Self-Hosted GitGuardian
 
-Set these environment variables in your MCP client configuration:
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `GITGUARDIAN_API_URL` | Your self-hosted GitGuardian base URL | `https://dashboard.gitguardian.mycorp.local` |
-| `GITGUARDIAN_AUTH_METHOD` | Authentication method: `token` or `web` | `token` |
-| `GITGUARDIAN_API_KEY` | Your API key (required for token auth) | `your-api-key-here` |
-
-### Configuration Examples
-
-#### Cursor with Self-Hosted GitGuardian (Token Authentication)
+For self-hosted GitGuardian instances, add the `GITGUARDIAN_API_URL` environment variable to your MCP configuration:
 
 ```json
 {
   "mcpServers": {
     "GitGuardianDeveloper": {
       "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/GitGuardian/gg-mcp.git",
-        "developer-mcp-server"
-      ],
+      "args": ["--from", "git+https://github.com/GitGuardian/gg-mcp.git", "developer-mcp-server"],
       "env": {
         "GITGUARDIAN_API_URL": "https://dashboard.gitguardian.mycorp.local",
         "GITGUARDIAN_AUTH_METHOD": "token",
@@ -214,20 +202,18 @@ Set these environment variables in your MCP client configuration:
 }
 ```
 
-#### Claude Desktop with Self-Hosted GitGuardian
+### GitGuardian EU Instance
+
+For the GitGuardian EU instance, use:
 
 ```json
 {
   "mcpServers": {
     "GitGuardianDeveloper": {
-      "command": "/path/to/uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/GitGuardian/gg-mcp.git",
-        "developer-mcp-server"
-      ],
+      "command": "uvx",
+      "args": ["--from", "git+https://github.com/GitGuardian/gg-mcp.git", "developer-mcp-server"],
       "env": {
-        "GITGUARDIAN_API_URL": "https://dashboard.gitguardian.mycorp.local",
+        "GITGUARDIAN_API_URL": "https://api.eu1.gitguardian.com/v1",
         "GITGUARDIAN_AUTH_METHOD": "token",
         "GITGUARDIAN_API_KEY": "your-api-key-here"
       }
@@ -236,37 +222,29 @@ Set these environment variables in your MCP client configuration:
 }
 ```
 
-### Authentication Methods for Self-Hosted Instances
+### OAuth Authentication (Alternative)
 
-#### Token Authentication (Recommended)
+For OAuth authentication instead of token authentication, omit the API key and set the auth method to `web`:
 
-For self-hosted instances, token authentication is the most reliable method:
+```json
+{
+  "mcpServers": {
+    "GitGuardianDeveloper": {
+      "command": "uvx",
+      "args": ["--from", "git+https://github.com/GitGuardian/gg-mcp.git", "developer-mcp-server"],
+      "env": {
+        "GITGUARDIAN_API_URL": "https://api.eu1.gitguardian.com/v1",
+        "GITGUARDIAN_AUTH_METHOD": "web"
+      }
+    }
+  }
+}
+```
 
-1. Generate an API token in your GitGuardian dashboard
-2. Set `GITGUARDIAN_AUTH_METHOD=token`
-3. Set `GITGUARDIAN_API_KEY` to your API token
-4. Set `GITGUARDIAN_API_URL` to your API endpoint
-
-#### OAuth Authentication
-
-OAuth is also supported for self-hosted instances:
-
-1. Set `GITGUARDIAN_AUTH_METHOD=web`
-2. Set `GITGUARDIAN_API_URL` to your API endpoint
-
-### API URL Formats
-
-For self-hosted instances, you only need to provide the **base URL** of your GitGuardian instance:
-
-- `https://dashboard.gitguardian.mycorp.local` - Base URL (recommended)
-- `https://gitguardian.company.com` - Custom domain base URL
-- `https://gg.internal.corp` - Internal domain base URL
-
-The MCP server will **automatically** append the correct API path (`/exposed/v1`) for self-hosted instances. You can also provide the full API URL if preferred:
-
-- `https://dashboard.gitguardian.mycorp.local/exposed/v1` - Full API URL (also works)
-
-The dashboard URL (used for OAuth authentication) will be automatically derived from the API URL.
+**Important Notes**:
+- The MCP server automatically derives the dashboard URL from the API URL, so you only need to set `GITGUARDIAN_API_URL`
+- For **token authentication** (default), you must provide your API key via `GITGUARDIAN_API_KEY`
+- For **OAuth authentication**, set `GITGUARDIAN_AUTH_METHOD=web` and the server will open a browser for authentication
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,15 @@ Resolve security incidents without context switching to the GitGuardian console.
 >
 > (2) Released this official MCP server to ensure you are using a legitimate and trusted implementation.
 
-## Key Features
+## Features supported
 
 - **Secret Scanning**: Scan code for leaked secrets, credentials, and API keys
 - **Incident Management**: View, assign, and resolve security incidents related to the project you are currently working.
 - **Honeytokens**: Create and manage honeytokens to detect unauthorized access
+- **Authentication Management**: Get authenticated user information and token details
+- **Token Management**: Revoke current API tokens
+
+> **Want more features?** Have a use case that's not covered? We'd love to hear from you! Submit your ideas and feedback on our [GitGuardian Roadmap](https://roadmap.gitguardian.com/tabs/10-ongoing/submit-idea) to help us prioritize new MCP server capabilities.
 
 ## Prompts examples
 

--- a/packages/developer_mcp_server/README.md
+++ b/packages/developer_mcp_server/README.md
@@ -45,7 +45,7 @@ The required API token scopes for this tool are:
 | `GITGUARDIAN_AUTH_METHOD` | Authentication method ('token' or 'web') | 'token' |
 | `GITGUARDIAN_API_KEY` | Your GitGuardian API key (required for token auth) | - |
 | `GITGUARDIAN_CLIENT_ID` | Your OAuth client ID (required for web auth) | - |
-| `GITGUARDIAN_API_URL` | GitGuardian base URL or API URL | `https://api.gitguardian.com/v1` (SaaS) `https://dashboard.gitguardian.mycorp.local` (Self-Hosted) |
+| `GITGUARDIAN_API_URL` | GitGuardian base URL or API URL | `https://api.gitguardian.com/v1` (SaaS US), `https://api.eu1.gitguardian.com/v1` (SaaS EU), `https://dashboard.gitguardian.mycorp.local` (Self-Hosted) |
 | `MCP_SERVER_HOST` | Host for the MCP server (used for OAuth redirect) | `localhost` |
 | `MCP_SERVER_PORT` | Port for the MCP server | `8000` |
 

--- a/packages/developer_mcp_server/README.md
+++ b/packages/developer_mcp_server/README.md
@@ -45,7 +45,7 @@ The required API token scopes for this tool are:
 | `GITGUARDIAN_AUTH_METHOD` | Authentication method ('token' or 'web') | 'token' |
 | `GITGUARDIAN_API_KEY` | Your GitGuardian API key (required for token auth) | - |
 | `GITGUARDIAN_CLIENT_ID` | Your OAuth client ID (required for web auth) | - |
-| `GITGUARDIAN_INSTANCE_URL` | Base URL for GitGuardian instance | `https://dashboard.gitguardian.com` |
+| `GITGUARDIAN_API_URL` | GitGuardian base URL or API URL | `https://api.gitguardian.com/v1` (SaaS) `https://dashboard.gitguardian.mycorp.local` (Self-Hosted) |
 | `MCP_SERVER_HOST` | Host for the MCP server (used for OAuth redirect) | `localhost` |
 | `MCP_SERVER_PORT` | Port for the MCP server | `8000` |
 

--- a/packages/secops_mcp_server/README.md
+++ b/packages/secops_mcp_server/README.md
@@ -53,6 +53,6 @@ The tools in this server require various API token scopes including:
 | `GITGUARDIAN_API_KEY` | Your GitGuardian API key (required for token auth) | - |
 | `GITGUARDIAN_CLIENT_ID` | Your OAuth client ID (required for web auth) | - |
 | `GITGUARDIAN_SCOPES` | Space-separated list of scopes (for OAuth) | All available scopes |
-| `GITGUARDIAN_API_URL` | GitGuardian base URL or API URL | `https://api.gitguardian.com/v1` (SaaS) `https://dashboard.gitguardian.mycorp.local` (Self-Hosted) |
+| `GITGUARDIAN_API_URL` | GitGuardian base URL or API URL | `https://api.gitguardian.com/v1` (SaaS US), `https://api.eu1.gitguardian.com/v1` (SaaS EU), `https://dashboard.gitguardian.mycorp.local` (Self-Hosted) |
 | `MCP_SERVER_HOST` | Host for the MCP server (used for OAuth redirect) | `localhost` |
 | `MCP_SERVER_PORT` | Port for the MCP server | `8000` |

--- a/packages/secops_mcp_server/README.md
+++ b/packages/secops_mcp_server/README.md
@@ -53,6 +53,6 @@ The tools in this server require various API token scopes including:
 | `GITGUARDIAN_API_KEY` | Your GitGuardian API key (required for token auth) | - |
 | `GITGUARDIAN_CLIENT_ID` | Your OAuth client ID (required for web auth) | - |
 | `GITGUARDIAN_SCOPES` | Space-separated list of scopes (for OAuth) | All available scopes |
-| `GITGUARDIAN_INSTANCE_URL` | Base URL for GitGuardian instance | `https://dashboard.gitguardian.com` |
+| `GITGUARDIAN_API_URL` | GitGuardian base URL or API URL | `https://api.gitguardian.com/v1` (SaaS) `https://dashboard.gitguardian.mycorp.local` (Self-Hosted) |
 | `MCP_SERVER_HOST` | Host for the MCP server (used for OAuth redirect) | `localhost` |
 | `MCP_SERVER_PORT` | Port for the MCP server | `8000` |


### PR DESCRIPTION
### Summary
- Simplified MCP server configuration by removing `GITGUARDIAN_DASHBOARD_URL` requirement
- Added support for GitGuardian EU SaaS instance (dashboard.eu1.gitguardian.com) and self-hosted 
- Enhanced documentation for self-hosted and multi-region deployments

### Changes
- **Configuration Simplification**: Dashboard URL now automatically derived from API URL
- **EU Instance Support**: Added URL normalization for `api.eu1.gitguardian.com` → `dashboard.eu1.gitguardian.com`
- **Documentation**: 
  - Added clear configuration examples for US SaaS, EU SaaS, and self-hosted instances
  - Clarified when API tokens are required vs OAuth authentication
  - Updated environment variable tables across all package READMEs
  - Added link to [submit ideas in GitGuardian roadmap](https://roadmap.gitguardian.com/tabs/10-ongoing/submit-idea)

### Breaking Changes
- Removed `GITGUARDIAN_DASHBOARD_URL` environment variable (automatically derived now)

### Migration
Existing configurations will continue to work. Users can optionally remove `GITGUARDIAN_DASHBOARD_URL` from their environment variables as it's no longer needed.

## Test Report

### ✅ URL Normalization Tests
- **US SaaS**: `https://api.gitguardian.com/v1` → dashboard: `https://dashboard.gitguardian.com` ✓
- **EU SaaS**: `https://api.eu1.gitguardian.com/v1` → dashboard: `https://dashboard.eu1.gitguardian.com` ✓
- **Self-hosted base URL**: `https://gitguardian.mycorp.com` → API: `https://gitguardian.mycorp.com/exposed/v1`, dashboard: `https://gitguardian.mycorp.com` ✓
- **Self-hosted full API URL**: `https://gitguardian.mycorp.com/exposed/v1` → dashboard: `https://gitguardian.mycorp.com` ✓
- **API subdomain**: `https://api.gitguardian.company.local/v1` → dashboard: `https://gitguardian.company.local` ✓

### ✅ EU Instance Support Tests
- **EU API URL recognition**: Correctly identifies `api.eu1.gitguardian.com` as SaaS instance ✓
- **EU dashboard derivation**: Maps EU API to correct EU dashboard URL ✓
- **EU base URL normalization**: `https://dashboard.eu1.gitguardian.com` → API: `https://dashboard.eu1.gitguardian.com/exposed/v1` ✓

### ✅ Configuration Simplification Tests
- **Dashboard URL derivation**: All instance types correctly derive dashboard URL from API URL ✓
- **Backward compatibility**: Existing configurations continue to work without `GITGUARDIAN_DASHBOARD_URL` ✓
- **Environment variable cleanup**: Verified no references to `GITGUARDIAN_DASHBOARD_URL` remain in codebase ✓

### ✅ Real-world Integration Tests
- **Local MCP server**: Successfully tested with self-hosted instance `https://on-prem.preprod.gitguardian.tech` ✓
- **Token authentication**: Verified API key authentication works with normalized URLs ✓
- **Client initialization**: All URL formats properly initialize GitGuardianClient ✓

### ✅ Documentation Tests
- **Configuration examples**: All JSON configurations validated for syntax and completeness ✓
- **Environment variable tables**: Updated across all package READMEs with EU instance support ✓
- **Migration notes**: Clear guidance provided for users upgrading configurations ✓

### Test Environment
- **Platform**: macOS 24.4.0
- **Python**: 3.13.4 
- **Package Manager**: uv
- **Test Instance**: GitGuardian self-hosted and SaaS EU